### PR TITLE
Fix invalid attribute for a RoleMetadata

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,5 +15,4 @@ galaxy_info:
     - system
     - development
 
-version: 1.0.0
 dependencies: []


### PR DESCRIPTION
The following issue happens running Ansible-Playbook with the role.

> ERROR! 'version' is not a valid attribute for a RoleMetadata
> 
> The error appears to have been in '/vagrant/.vagrant/provision/roles/yfix.bash-cmd/meta/main.yml': line 2, column 1, but may
> be elsewhere in the file depending on the exact syntax problem.
> 
> The offending line appears to be:
> ---
> 
> galaxy_info:
> ^ here
> 
> Ansible failed to complete successfully. Any error output should be
> visible above. Please fix these errors and try again.
